### PR TITLE
use msys on windows, override install command

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -27,6 +27,7 @@ my $builder = My::ModuleBuild->new(
     alien_bin_requires => {
         'Alien::gmake' => '0.11',
     },
+    alien_msys => 1,
     configure_requires => {
         'Alien::Base::ModuleBuild' => 0.016,
         'Capture::Tiny'            => 0,
@@ -49,7 +50,7 @@ my $builder = My::ModuleBuild->new(
         "%{gmake} --directory=build/gcc CXX=$cxx"
     ],
     alien_install_commands => [
-        "%{gmake} --directory=build/gcc CXX=$cxx prefix=%s install"
+        "%{gmake} --directory=build/gcc CXX=$cxx INSTALL=install prefix=%s install"
     ],
     alien_name       => 'astyle',
     alien_repository => [


### PR DESCRIPTION
The "make install" command requires the "install" command on windows. This is most easily provided by Alien::MSYS (via the alien_msys directive).

Also the makefile assumes that USER is set and (incorrectly) that the user has a corresponding group with the same name.  We can get around this by overriding INSTALL in the "make install" line.

This should make MSWin32 more reliable, and possibly some other platforms as well.  Note that the test suite did not pass for me.  Things like `-x` do not necessary work the way that you think they should on windows.  Also, if you are using the system astyle Alien::astyle->bin_dir will return an empty list (the executable should having already been in the directory).  I use `Test::Alien` to test executable, but this may be overkill for you.