### PR TITLE
Corrections to system probe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,7 @@ notifications:
     template:
       - "Alien::astyle build %{result}. %{author} says '%{commit_message}'"
       - "%{build_url} %{compare_url}"
+
+env:
+  - ALIEN_INSTALL_TYPE=share
+  - ALIEN_INSTALL_TYPE=system

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: perl
 # v0.004_000
 
+addons:
+  apt:
+    packages:
+      - astyle
+
 perl:
   - "5.8"
   - "5.10"

--- a/inc/My/ModuleBuild.pm
+++ b/inc/My/ModuleBuild.pm
@@ -20,29 +20,23 @@ sub alien_check_installed_version {
     }
 
     # run `astyle --version`, check for valid output
-    my $version_stdout;
-    my $version_stderr = capture_stderr {
-        $version_stdout = [`$astyle_path --version`];
-    };
-    if (($version_stderr ne q{}) and
-        ($version_stderr !~ m/an\'t\ exec/xms) and
-        ($version_stderr !~ m/o\ such\ file/xms) and
-        ($version_stderr !~ m/is\ not\ recognized/xms) and # MS Windows in AppVeyor
-        ($version_stderr !~ m/internal\ or\ external\ command/xms) # MS Windows in AppVeyor
-        ) {
+    my $version_stderr = [split /\r?\n/, capture_stderr {
+        system "$astyle_path --version";
+    }];
+    if($? != 0) {
         print {*STDERR} 'WARNING WAAMBIV00: Alien::astyle experienced an unrecognized error while attempting to determine installed version...', 
             "\n", $version_stderr, "\n", 'Trying to continue...', "\n";
     }
-    if ((scalar @{$version_stdout}) > 1) {
+    if ((scalar @{$version_stderr}) > 1) {
         print {*STDERR} 'WARNING WAAMBIV01: Alien::astyle received too much output while attempting to determine installed version...', 
-            "\n", Dumper($version_stdout), "\n", 'Trying to continue...', "\n";
+            "\n", Dumper($version_stderr), "\n", 'Trying to continue...', "\n";
     }
 
-#    print {*STDERR} '<<< DEBUG >>>: in ModuleBuild::alien_check_installed_version(), have $version_stdout = ', Dumper($version_stdout), "\n";
-    my $version_stdout_0 = $version_stdout->[0];
-    if ((defined $version_stdout_0) and
-        ((substr $version_stdout_0, 0, 22) eq 'Artistic Style Version') and 
-        ($version_stdout_0 =~ m/([\d\.]+)$/xms)) {
+#    print {*STDERR} '<<< DEBUG >>>: in ModuleBuild::alien_check_installed_version(), have $version_stderr = ', Dumper($version_stderr), "\n";
+    my $version_stderr_0 = $version_stderr->[0];
+    if ((defined $version_stderr_0) and
+        ((substr $version_stderr_0, 0, 22) eq 'Artistic Style Version') and 
+        ($version_stderr_0 =~ m/([\d\.]+)$/xms)) {
         my $version = $1;
 #        print {*STDERR} '<<< DEBUG >>>: in ModuleBuild::alien_check_installed_version(), returning $version = ', $version, "\n";
         return $version;

--- a/inc/My/ModuleBuild.pm
+++ b/inc/My/ModuleBuild.pm
@@ -7,7 +7,7 @@ use Alien::Base::ModuleBuild;
 use base qw( Alien::Base::ModuleBuild );
 
 use File::chdir;
-use Capture::Tiny qw( capture_stderr );
+use Capture::Tiny qw( capture_merged );
 use Data::Dumper;
 use IPC::Cmd qw(can_run);
 
@@ -20,23 +20,23 @@ sub alien_check_installed_version {
     }
 
     # run `astyle --version`, check for valid output
-    my $version_stderr = [split /\r?\n/, capture_stderr {
+    my $version = [split /\r?\n/, capture_merged {
         system "$astyle_path --version";
     }];
     if($? != 0) {
         print {*STDERR} 'WARNING WAAMBIV00: Alien::astyle experienced an unrecognized error while attempting to determine installed version...', 
-            "\n", $version_stderr, "\n", 'Trying to continue...', "\n";
+            "\n", $version, "\n", 'Trying to continue...', "\n";
     }
-    if ((scalar @{$version_stderr}) > 1) {
+    if ((scalar @{$version}) > 1) {
         print {*STDERR} 'WARNING WAAMBIV01: Alien::astyle received too much output while attempting to determine installed version...', 
-            "\n", Dumper($version_stderr), "\n", 'Trying to continue...', "\n";
+            "\n", Dumper($version), "\n", 'Trying to continue...', "\n";
     }
 
-#    print {*STDERR} '<<< DEBUG >>>: in ModuleBuild::alien_check_installed_version(), have $version_stderr = ', Dumper($version_stderr), "\n";
-    my $version_stderr_0 = $version_stderr->[0];
-    if ((defined $version_stderr_0) and
-        ((substr $version_stderr_0, 0, 22) eq 'Artistic Style Version') and 
-        ($version_stderr_0 =~ m/([\d\.]+)$/xms)) {
+#    print {*STDERR} '<<< DEBUG >>>: in ModuleBuild::alien_check_installed_version(), have $version = ', Dumper($version), "\n";
+    my $version_0 = $version->[0];
+    if ((defined $version_0) and
+        ((substr $version_0, 0, 22) eq 'Artistic Style Version') and 
+        ($version_0 =~ m/([\d\.]+)$/xms)) {
         my $version = $1;
 #        print {*STDERR} '<<< DEBUG >>>: in ModuleBuild::alien_check_installed_version(), returning $version = ', $version, "\n";
         return $version;

--- a/t/03_binary_version.t
+++ b/t/03_binary_version.t
@@ -2,26 +2,25 @@ use strict;
 use warnings;
 our $VERSION = 0.001_000;
 
-use Test::More tests => 7;
+use Test::More tests => 6;
 use File::Spec;
-use Capture::Tiny qw( capture_stderr );
+use Capture::Tiny qw( capture_merged );
+use Env qw( @PATH );
 
 use_ok('Alien::astyle');
 
-my $astyle_bin_dir = Alien::astyle->bin_dir();
-my $astyle_bin = File::Spec->catfile( $astyle_bin_dir, 'astyle' );
+unshift @PATH, Alien::astyle->bin_dir;
 
-my $version_stdout = q{};
-my $version_stderr = capture_stderr {
-    $version_stdout = [`$astyle_bin --version`];
-};
-is($version_stderr, q{}, '`astyle --version` executes without displaying errors');
-cmp_ok((scalar @{$version_stdout}), '==', 1, '`astyle --version` executes with 1 line of output');
+my $version = [ split /\r?\n/, capture_merged {
+    system "astyle --version";
+}];
+#is($version_stderr, q{}, '`astyle --version` executes without displaying errors');
+cmp_ok((scalar @{$version}), '==', 1, '`astyle --version` executes with 1 line of output');
 
-my $version_stdout_0 = $version_stdout->[0];
-ok(defined $version_stdout_0, '`astyle --version` 1 line of output is defined');
-is((substr $version_stdout_0, 0, 22), 'Artistic Style Version', '`astyle --version` 1 line of output starts correctly');
-ok($version_stdout_0 =~ m/([\d\.]+)$/xms, '`astyle --version` 1 line of output ends correctly');
+my $version_0 = $version->[0];
+ok(defined $version_0, '`astyle --version` 1 line of output is defined');
+is((substr $version_0, 0, 22), 'Artistic Style Version', '`astyle --version` 1 line of output starts correctly');
+ok($version_0 =~ m/([\d\.]+)$/xms, '`astyle --version` 1 line of output ends correctly');
 
 my $version_split = [split /[.]/, $1];
 my $version_split_0 = $version_split->[0] + 0;


### PR DESCRIPTION
At least for the `astyle` provided for my Debian Linux, the version number is printed to stderr, not stdout.  Also, checking $? is a reliable way for catching things like "command not found".